### PR TITLE
Move express and prom-client to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   },
   "homepage": "https://github.com/teamzerolabs/mindseye#readme",
   "devDependencies": {
+    "express": "^4.17.1",
+    "prom-client": "^11.5.3"
     "@types/express": "^4.17.2",
     "@types/node": "^13.7.0",
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "express": "^4.17.1",
-    "prom-client": "^11.5.3"
   }
 }


### PR DESCRIPTION
Both of them should be installed by package using this library, and express is even optional